### PR TITLE
Iowrap

### DIFF
--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -21,6 +21,7 @@ module Hydra
     autoload :RawImage
     autoload :Logger
     autoload :TempfileService
+    autoload :IoDecorator
 
     # services
     autoload :RetrieveSourceFileService,         'hydra/derivatives/services/retrieve_source_file_service'

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -1,6 +1,7 @@
 require 'active_fedora'
 require 'hydra/derivatives/railtie' if defined?(Rails)
 require 'deprecation'
+
 module Hydra
   module Derivatives
     extend ActiveSupport::Concern

--- a/lib/hydra/derivatives/document.rb
+++ b/lib/hydra/derivatives/document.rb
@@ -25,8 +25,7 @@ module Hydra
         end
         out_file = Hydra::Derivatives::IoDecorator.new(File.open(new_output, "rb"))
         out_file.mime_type = mime_type
-        out_file.original_name = destination_name
-        output_file_service.call(object, out_file.read, destination_name, mime_type: mime_type)
+        output_file_service.call(object, out_file, destination_name)
         File.unlink(out_file)
       end
 

--- a/lib/hydra/derivatives/document.rb
+++ b/lib/hydra/derivatives/document.rb
@@ -23,7 +23,9 @@ module Hydra
             new_output = File.join(Hydra::Derivatives.temp_file_base, [File.basename(f.path).sub(File.extname(f.path), ''), file_suffix].join('.'))
           end
         end
-        out_file = File.open(new_output, "rb")
+        out_file = Hydra::Derivatives::IoDecorator.new(File.open(new_output, "rb"))
+        out_file.mime_type = mime_type
+        out_file.original_name = destination_name
         output_file_service.call(object, out_file.read, destination_name, mime_type: mime_type)
         File.unlink(out_file)
       end

--- a/lib/hydra/derivatives/image.rb
+++ b/lib/hydra/derivatives/image.rb
@@ -56,13 +56,11 @@ module Hydra
       def write_image(destination_name, format, xfrm)
         output_io = Hydra::Derivatives::IoDecorator.new(StringIO.new) 
         output_io.mime_type = new_mime_type(format)
-        output_io.original_name = destination_name
 
         xfrm.write(output_io)
         output_io.rewind
-        mime_type = new_mime_type(format)
-        output_file_service.call(object, output_io, destination_name, mime_type: mime_type)
 
+        output_file_service.call(object, output_io, destination_name)
       end
 
       # Override this method if you want a different transformer, or need to load the

--- a/lib/hydra/derivatives/image.rb
+++ b/lib/hydra/derivatives/image.rb
@@ -54,11 +54,14 @@ module Hydra
       end
 
       def write_image(destination_name, format, xfrm)
-        stream = StringIO.new
-        xfrm.write(stream)
-        stream.rewind
+        output_io = Hydra::Derivatives::IoDecorator.new(StringIO.new) 
+        output_io.mime_type = new_mime_type(format)
+        output_io.original_name = destination_name
+
+        xfrm.write(output_io)
+        output_io.rewind
         mime_type = new_mime_type(format)
-        output_file_service.call(object, stream, destination_name, mime_type: mime_type)
+        output_file_service.call(object, output_io, destination_name, mime_type: mime_type)
 
       end
 

--- a/lib/hydra/derivatives/io_decorator.rb
+++ b/lib/hydra/derivatives/io_decorator.rb
@@ -1,0 +1,15 @@
+# Nieve implementation of IO wrapper class that adds mime_type and original_name attributes.
+# This is done so the attributes do not have to be passed as additional arguments, 
+#  and are attached properly to the object they describe.
+#
+#
+#  Use SimpleDelegator to wrap the given class or instance
+require 'delegate'
+
+module Hydra
+  module Derivatives
+    class IoDecorator < SimpleDelegator
+      attr_accessor :mime_type, :original_name
+    end
+  end
+end

--- a/lib/hydra/derivatives/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/jpeg2k_image.rb
@@ -34,8 +34,9 @@ module Hydra
             self.class.encode(f.path, recipe, output_file)
           end
         end
-        out_file = File.open(output_file, "rb")
-        # object.add_file(out_file.read, path: destination_name, mime_type: 'image/jp2')
+        out_file = Hydra::Derivatives::IoDecorator.new(File.open(output_file, "rb"))
+        out_file.mime_type = "image/jp2"
+        out_file.original_name = destination_name
         output_file_service.call(object, out_file.read, destination_name, mime_type: 'image/jp2')
 
         File.unlink(output_file)

--- a/lib/hydra/derivatives/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/jpeg2k_image.rb
@@ -36,8 +36,7 @@ module Hydra
         end
         out_file = Hydra::Derivatives::IoDecorator.new(File.open(output_file, "rb"))
         out_file.mime_type = "image/jp2"
-        out_file.original_name = destination_name
-        output_file_service.call(object, out_file.read, destination_name, mime_type: 'image/jp2')
+        output_file_service.call(object, out_file, destination_name)
 
         File.unlink(output_file)
       end

--- a/lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
@@ -11,13 +11,15 @@ module Hydra::Derivatives
     # NOTE: Uses basic containment. If you want to use direct containment (ie. with PCDM) you must use a different service (ie. Hydra::Works::AddFileToGenericFile Service)
     #
     # @param [ActiveFedora::Base] object file is be persisted to
-    # @param [File] filestream to be added
-    # @param [String] destination_name path to file
-    # @option opts [String] mime_type mime type of derivative
+    # @param [File] filestream to be added, should respond to :mime_type and :original_name
+    #   original_name will get used as the path for a chile resource in fedora, it is not a path to a file on disk.
 
-    def self.call(object, file, destination_name, opts={})
-      object.add_file(file, path: destination_name, mime_type: opts[:mime_type])
+    def self.call(object, file, destination_path)
+      o_name = determine_original_name(file)
+      m_type = determine_mime_type(file)
+      object.add_file(file, path: destination_path, mime_type: m_type, original_name: o_name)
       object.save
     end
+
   end
 end

--- a/lib/hydra/derivatives/services/persist_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_output_file_service.rb
@@ -4,12 +4,28 @@ module Hydra::Derivatives
     # Persists the file within the object at destination_name.  Uses basic containment.
     # If you want to use direct containment (ie. with PCDM) you must use a different service (ie. Hydra::Works::AddFileToGenericFile Service)
     # @param [Object] object the source file is attached to
-    # @param [File] filestream to be added
-    # @param [String] destination_name path to file
-    # @option opts Specific implementations can use this as needed
+    # @param [File] filestream to be added, should respond to :mime_type, :original_name
+    # @param [String] destination_name is the fedora path at which the child resource will be found or created beneath the object.
 
-    def self.call(object, file, destination_name, opts={})
+    def self.call(object, file, destination_path)
       raise NotImplementedError, "PersistOutputFileService is an abstract class. Implement `call' on #{self.class.name}"
     end
+
+    def self.determine_original_name( file )
+      if file.respond_to? :original_name
+         file.original_name
+       else
+         "derivative"
+       end
+    end
+
+    def self.determine_mime_type( file )
+      if file.respond_to? :mime_type
+         file.mime_type
+       else
+         "appliction/octet-stream"
+       end
+    end
+
   end
 end

--- a/lib/hydra/derivatives/shell_based_processor.rb
+++ b/lib/hydra/derivatives/shell_based_processor.rb
@@ -35,7 +35,9 @@ module Hydra
         Hydra::Derivatives::TempfileService.create(source_file) do |f|
           self.class.encode(f.path, options, output_file)
         end
-        out_file = File.open(output_file, "rb")
+        out_file = Hydra::Derivatives::IoDecorator.new(File.open(output_file, "rb"))
+        out_file.mime_type = mime_type
+        out_file.original_name = destination_name
         output_file_service.call(object, out_file.read, destination_name, mime_type: mime_type)
         File.unlink(output_file)
       end

--- a/lib/hydra/derivatives/shell_based_processor.rb
+++ b/lib/hydra/derivatives/shell_based_processor.rb
@@ -37,8 +37,7 @@ module Hydra
         end
         out_file = Hydra::Derivatives::IoDecorator.new(File.open(output_file, "rb"))
         out_file.mime_type = mime_type
-        out_file.original_name = destination_name
-        output_file_service.call(object, out_file.read, destination_name, mime_type: mime_type)
+        output_file_service.call(object, out_file, destination_name)
         File.unlink(output_file)
       end
 

--- a/spec/services/persist_basic_contained_output_file_service_spec.rb
+++ b/spec/services/persist_basic_contained_output_file_service_spec.rb
@@ -13,7 +13,10 @@ describe Hydra::Derivatives::PersistBasicContainedOutputFileService do
   let(:file)              { File.new(file_path)}
   let(:destination_name)  { 'the_derivative_name' }
 
-  context "when file is basic contained (default assumption)" do  # alas, we have to support this as the default because all legacy code (and fedora 3 systems) created basic contained files
+  # alas, we have to support this as the default because all legacy code (and fedora 3 systems) created basic contained files
+  # The new signature does not have a destination_name option.  There is a default string that will get applied, but his might
+  # not be sufficient.
+  context "when file is basic contained (default assumption)" do  
     let(:object)          { BasicContainerObject.new  }
     it "persists the file to the specified destination on the given object" do
       described_class.call(object, "fake file content", destination_name)


### PR DESCRIPTION
Implement a decorator class to wrap IO objects and provide mime_type and original_name attribute accessors.

Change the signature for the call method of OutputFileService.  It accepts and object and file.  The file should be interrogated for relevant attributes.  Currently these attributes are mime_type and original_name.