### PR TITLE
change call to transform_file, in the deprecated method. Fixes #58

### DIFF
--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -118,7 +118,7 @@ module Hydra
     end
 
     def transform_datastream(file_name, transform_directives, opts={})
-      transform_file(file_name, transform_directives, opts={})
+      transform_file(file_name, transform_directives, opts)
     end
     deprecation_deprecate :transform_datastream
 


### PR DESCRIPTION
transform_datastream, to not pass a default options values,
since the method def for transform_file already sets the
default values.