### PR TITLE
make quality be passed when creating an image

### DIFF
--- a/lib/hydra/derivatives/processors/image.rb
+++ b/lib/hydra/derivatives/processors/image.rb
@@ -21,7 +21,8 @@ module Hydra::Derivatives::Processors
       name = directives.fetch(:label, format)
       destination_name = output_filename_for(name)
       size = directives.fetch(:size, nil)
-      create_resized_image(destination_name, size, format)
+      quality = directives.fetch(:quality, nil)
+      create_resized_image(destination_name, size, format, quality)
     end
 
     protected

--- a/spec/processors/image_spec.rb
+++ b/spec/processors/image_spec.rb
@@ -9,11 +9,11 @@ describe Hydra::Derivatives::Processors::Image do
   before { allow(subject).to receive(:output_file).with(file_name).and_return(output_file) }
 
   describe "when arguments are passed as a hash" do
-    let(:directives) { { label: :thumb, size: "200x300>", format: 'png' } }
+    let(:directives) { { label: :thumb, size: "200x300>", format: 'png', quality: 75 } }
     let(:file_name) { 'thumbnail' }
 
-    it "uses the specified size and name" do
-      expect(subject).to receive(:create_resized_image).with(file_name, "200x300>", 'png')
+    it "uses the specified size and name and quality" do
+      expect(subject).to receive(:create_resized_image).with(file_name, "200x300>", 'png', 75)
       subject.process
     end
   end


### PR DESCRIPTION
The quality param in http://www.imagemagick.org/script/command-line-options.php#quality allows setting of image compression. The hydra-derivatives derivatives/image.rb code was previously accepting/passing it only through protected methods.
This pull request allows it to be passed in by the user when declaring the directives.