### PR TITLE
Convert documents to pdf and jpg, fixes #109

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -2,27 +2,42 @@ module Hydra::Derivatives::Processors
   class Document < Processor
     include ShellBasedProcessor
 
-    def self.encode(path, _options, output_file)
-      format = File.extname(output_file).sub('.', '')
-      outdir = File.dirname(output_file)
+    def self.encode(path, format, outdir)
       execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{path}"
     end
 
-    def encode_file(file_suffix, options = {})
-      new_output = ''
-      if file_suffix == 'jpg'
-        temp_file = File.join(Hydra::Derivatives.temp_file_base, [directives.fetch(:label).to_s, 'pdf'].join('.'))
-        new_output = File.join(Hydra::Derivatives.temp_file_base, [File.basename(temp_file).sub(File.extname(temp_file), ''), file_suffix].join('.'))
-        self.class.encode(source_path, options, temp_file)
-        self.class.encode(temp_file, options, output_file(file_suffix))
-        File.unlink(temp_file)
-      else
-        self.class.encode(source_path, options, output_file(file_suffix))
-        new_output = File.join(Hydra::Derivatives.temp_file_base, [directives.fetch(:label).to_s, file_suffix].join('.'))
-      end
-      out_file = File.open(new_output, "rb")
-      output_file_service.call(out_file, directives)
-      File.unlink(out_file)
+    # Converts the document to the format specified in the directives hash.
+    # TODO: file_suffix and options are passed from ShellBasedProcessor.process but are not needed.
+    #       A refactor could simplify this.
+    def encode_file(_file_suffix, _options = {})
+      convert_to_format
+    ensure
+      FileUtils.rm_f(converted_file)
     end
+
+    private
+
+      # For jpeg files, a pdf is created from the original source and then passed to the Image processor class
+      # so we can get a better conversion with resizing options. Otherwise, the ::encode method is used.
+      def convert_to_format
+        if directives.fetch(:format) == "jpg"
+          Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
+        else
+          output_file_service.call(File.read(converted_file), directives)
+        end
+      end
+
+      def converted_file
+        @converted_file ||= if directives.fetch(:format) == "jpg"
+                              convert_to("pdf")
+                            else
+                              convert_to(directives.fetch(:format))
+                            end
+      end
+
+      def convert_to(format)
+        self.class.encode(source_path, format, Hydra::Derivatives.temp_file_base)
+        File.join(Hydra::Derivatives.temp_file_base, [File.basename(source_path, ".*"), format].join('.'))
+      end
   end
 end

--- a/spec/processors/document_spec.rb
+++ b/spec/processors/document_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::Processors::Document do
+  let(:source_path)    { File.join(fixture_path, "test.doc") }
+  let(:output_service) { Hydra::Derivatives::PersistBasicContainedOutputFileService }
+
+  before { allow(subject).to receive(:converted_file).and_return(converted_file) }
+
+  subject { described_class.new(source_path, directives) }
+
+  describe "#encode_file" do
+    context "when converting to jpg" do
+      let(:directives)     { { format: "jpg" } }
+      let(:converted_file) { "path/to/pdf/created/from/original" }
+      let(:mock_processor) { double }
+
+      before do
+        allow(Hydra::Derivatives::Processors::Image).to receive(:new).with(converted_file, directives).and_return(mock_processor)
+      end
+
+      it "creates a thumbnail of the document using a pdf created from the original" do
+        expect(mock_processor).to receive(:process)
+        expect(File).to receive(:unlink).with(converted_file)
+        subject.encode_file("jpg")
+      end
+    end
+
+    context "when converting to another format" do
+      let(:directives)     { { format: "png" } }
+      let(:converted_file) { "path/to/converted.png" }
+      let(:mock_content)   { "mocked png content" }
+
+      before { allow(File).to receive(:read).with(converted_file).and_return(mock_content) }
+      it "creates a thumbnail of the document" do
+        expect(output_service).to receive(:call).with(mock_content, directives)
+        expect(File).to receive(:unlink).with(converted_file)
+        subject.encode_file("png")
+      end
+    end
+  end
+end

--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -14,40 +14,59 @@ describe "Transcoding" do
                                       outputs: [{ label: :thumb, size: "100x100>", url: "#{uri}/original_file_thumb" }])
           FullTextExtract.create(self, source: :original_file, outputs: [{ url: "#{uri}/fulltext" }])
         when 'audio/wav'
-          AudioDerivatives.create(self, source: :original_file, outputs: [{ label: :mp3, format: 'mp3', url: "#{uri}/mp3" }, { label: :ogg, format: 'ogg', url: "#{uri}/ogg" }])
+          AudioDerivatives.create(self, source: :original_file,
+                                        outputs: [
+                                          { label: :mp3, format: 'mp3', url: "#{uri}/mp3" },
+                                          { label: :ogg, format: 'ogg', url: "#{uri}/ogg" }])
         when 'video/avi'
           VideoDerivatives.create(self, source: :original_file,
                                         outputs: [
-                                          { label: :mp4, format: 'mp4', url: "#{uri}/original_file_mp4" },
-                                          { label: :webm, format: 'webm', url: "#{uri}/original_file_webm" },
-                                          { label: :thumbnail, format: 'jpg', url: "#{uri}/thumbnail" }])
+                                          { label: :mp4,       format: 'mp4',  url: "#{uri}/original_file_mp4" },
+                                          { label: :webm,      format: 'webm', url: "#{uri}/original_file_webm" },
+                                          { label: :thumbnail, format: 'jpg',  url: "#{uri}/thumbnail" }])
         when 'image/png', 'image/jpg'
           ImageDerivatives.create(self, source: :original_file,
                                   outputs: [
                                     { label: :medium, size: "300x300>", url: "#{uri}/original_file_medium" },
-                                    { label: :thumb, size: "100x100>", url: "#{uri}/original_file_thumb" },
-                                    { label: :access, url: "#{uri}/access", format: 'jpg' },
+                                    { label: :thumb,  size: "100x100>", url: "#{uri}/original_file_thumb" },
+                                    { label: :access, format: 'jpg',    url: "#{uri}/access" },
           ])
         when 'application/vnd.ms-powerpoint'
-          DocumentDerivatives.create(self, source: :original_file, outputs: [{ label: :preservation, format: 'pptx' }, { label: :access, format: 'pdf' }, { label: :thumnail, format: 'jpg' }])
+          DocumentDerivatives.create(self, source: :original_file,
+                                           outputs: [
+                                             { label: :preservation, format: 'pptx', url: "#{uri}/original_file_preservation" },
+                                             { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
         when 'text/rtf'
-          DocumentDerivatives.create(self, source: :original_file, outputs: [{ label: :preservation, format: 'odf' }, { label: :access, format: 'pdf' }, { label: :thumnail, format: 'jpg' }])
+          DocumentDerivatives.create(self, source: :original_file,
+                                           outputs: [
+                                             { label: :preservation, format: 'odf', url: "#{uri}/original_file_preservation" },
+                                             { label: :access,       format: 'pdf', url: "#{uri}/original_file_access" },
+                                             { label: :thumnail,     format: 'jpg', url: "#{uri}/original_file_thumbnail" }])
         when 'application/msword'
-          DocumentDerivatives.create(self, source: :original_file, outputs: [{ label: :preservation, format: 'docx' }, { label: :access, format: 'pdf' }, { label: :thumnail, format: 'jpg' }])
+          DocumentDerivatives.create(self, source: :original_file,
+                                           outputs: [
+                                             { label: :preservation, format: 'docx', url: "#{uri}/original_file_preservation" },
+                                             { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
         when 'application/vnd.ms-excel'
-          DocumentDerivatives.create(self, source: :original_file, outputs: [{ label: :preservation, format: 'xslx' }, { label: :access, format: 'pdf' }, { label: :thumnail, format: 'jpg' }])
+          DocumentDerivatives.create(self, source: :original_file,
+                                           outputs: [
+                                             { label: :preservation, format: 'xslx', url: "#{uri}/original_file_preservation" },
+                                             { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
         when 'image/tiff'
-          Jpeg2kImageDerivatives.create(self, source: :original_file, outputs: [
-                                          { label: :resized, recipe: :default, resize: "600x600>", processor: 'jpeg2k_image', url: "#{uri}/resized" },
-                                          { label: :config_lookup, recipe: :default, processor: 'jpeg2k_image', url: "#{uri}/config_lookup" },
-                                          { label: :string_recipe, recipe: '-quiet', processor: 'jpeg2k_image', url: "#{uri}/string_recipe" },
-                                          { label: :diy, processor: 'jpeg2k_image', url: "#{uri}/original_file_diy" }
-                                        ])
+          Jpeg2kImageDerivatives.create(self, source: :original_file,
+                                              outputs: [
+                                                { label: :resized,       recipe: :default, processor: 'jpeg2k_image', resize: "600x600>", url: "#{uri}/resized" },
+                                                { label: :config_lookup, recipe: :default, processor: 'jpeg2k_image',                     url: "#{uri}/config_lookup" },
+                                                { label: :string_recipe, recipe: '-quiet', processor: 'jpeg2k_image',                     url: "#{uri}/string_recipe" },
+                                                { label: :diy,                             processor: 'jpeg2k_image',                     url: "#{uri}/original_file_diy" }])
         when 'image/x-adobe-dng'
-          ImageDerivatives.create(self, source: :original_file, outputs: [
-                                    { label: :access, size: "300x300>", format: 'jpg', processor: :raw_image },
-                                    { label: :thumb, size: "100x100>", format: 'jpg', processor: :raw_image }
-                                  ])
+          ImageDerivatives.create(self, source: :original_file,
+                                        outputs: [
+                                          { label: :access, size: "300x300>", format: 'jpg', processor: :raw_image },
+                                          { label: :thumb,  size: "100x100>", format: 'jpg', processor: :raw_image }])
         end
       end
     end
@@ -245,12 +264,13 @@ describe "Transcoding" do
   end
 
   describe "with an attached word doc format", unless: in_travis? do
-    let(:filename) { File.expand_path('../../fixtures/test.doc', __FILE__) }
+    let(:filename)   { File.expand_path('../../fixtures/test.doc', __FILE__) }
     let(:attachment) { File.open(filename) }
 
     let(:file) do
       GenericFile.new(mime_type_from_fits: 'application/msword').tap do |t|
         t.original_file.content = attachment
+        t.original_file.mime_type = 'application/msword'
         t.save
       end
     end
@@ -268,12 +288,13 @@ describe "Transcoding" do
   end
 
   describe "with an attached excel format", unless: in_travis? do
-    let(:filename) { File.expand_path('../../fixtures/test.xls', __FILE__) }
+    let(:filename)   { File.expand_path('../../fixtures/test.xls', __FILE__) }
     let(:attachment) { File.open(filename) }
 
     let(:file) do
       GenericFile.new(mime_type_from_fits: 'application/vnd.ms-excel').tap do |t|
         t.original_file.content = attachment
+        t.original_file.mime_type = 'application/vnd.ms-excel'
         t.save
       end
     end


### PR DESCRIPTION
This improves the function of Hydra::Derivatives::Processors::Document and refactors its tests.

* correctly converts documents to pdf and other non-image formats
* jpg conversion is delegated to Hydra::Derivatives::Processors::Image so files are correctly resized
* adds additional units tests; refactors existing tests