### PR TITLE
Directive option for layer

### DIFF
--- a/lib/hydra/derivatives/processors/image.rb
+++ b/lib/hydra/derivatives/processors/image.rb
@@ -28,7 +28,7 @@ module Hydra::Derivatives::Processors
       end
 
       def create_image
-        xfrm = load_image_transformer
+        xfrm = selected_layers(load_image_transformer)
         yield(xfrm) if block_given?
         xfrm.format(directives.fetch(:format))
         xfrm.quality(quality.to_s) if quality
@@ -56,6 +56,12 @@ module Hydra::Derivatives::Processors
 
       def quality
         directives.fetch(:quality, nil)
+      end
+
+      def selected_layers(image)
+        layer_index = directives.fetch(:layer, false)
+        return image unless layer_index
+        image.layers[layer_index]
       end
   end
 end

--- a/spec/processors/image_spec.rb
+++ b/spec/processors/image_spec.rb
@@ -5,20 +5,38 @@ describe Hydra::Derivatives::Processors::Image do
   subject { described_class.new(file_name, directives) }
 
   context "when arguments are passed as a hash" do
-    let(:directives)       { { label: :thumb, size: "200x300>", format: 'png', quality: 75 } }
     let(:mock_transformer) { double("MockTransformer") }
+    let(:mock_layer)       { double("MockLayer") }
 
-    before do
-      allow(subject).to receive(:load_image_transformer).and_return(mock_transformer)
-      allow(subject).to receive(:write_image).with(mock_transformer)
+    before { allow(subject).to receive(:load_image_transformer).and_return(mock_transformer) }
+
+    context "using image directives" do
+      let(:directives) { { label: :thumb, size: "200x300>", format: 'png', quality: 75 } }
+
+      before { allow(subject).to receive(:write_image).with(mock_transformer) }
+
+      it "uses the specified size and name and quality" do
+        expect(mock_transformer).to receive(:flatten)
+        expect(mock_transformer).to receive(:resize).with("200x300>")
+        expect(mock_transformer).to receive(:format).with("png")
+        expect(mock_transformer).to receive(:quality).with("75")
+        subject.process
+      end
     end
 
-    it "uses the specified size and name and quality" do
-      expect(mock_transformer).to receive(:flatten)
-      expect(mock_transformer).to receive(:resize).with("200x300>")
-      expect(mock_transformer).to receive(:format).with("png")
-      expect(mock_transformer).to receive(:quality).with("75")
-      subject.process
+    context "using pdf directives" do
+      let(:directives) { { label: :thumb, size: "200x300>", format: 'pdf', layer: 0, quality: 75 } }
+
+      before { allow(subject).to receive(:write_image).with(mock_layer) }
+
+      it "uses the specified size and name and quality" do
+        expect(mock_transformer).to receive(:layers).and_return([mock_layer])
+        expect(mock_layer).to receive(:flatten)
+        expect(mock_layer).to receive(:resize).with("200x300>")
+        expect(mock_layer).to receive(:format).with("pdf")
+        expect(mock_layer).to receive(:quality).with("75")
+        subject.process
+      end
     end
   end
 


### PR DESCRIPTION
Flattening images in 9df9746fb91c00b5cce8305f6a990a67fbd34d43 created a new problem with multi-page pdf files. When creating thumbnails for these files, the resulting image has all of the pages layered one on top of the other instead of just the first page.

Since we need to keep the `flatten` option so that a pdf's background is retained properly, I decided to add a `layer` directive so that the user can decide which layer to choose. This also allows for additional tweaking should there be other multi-layer formats and the user needs to select a specific layer for derivative creation.