### PR TITLE
Default to first page for pdf images

### DIFF
--- a/lib/hydra/derivatives/processors/image.rb
+++ b/lib/hydra/derivatives/processors/image.rb
@@ -59,9 +59,13 @@ module Hydra::Derivatives::Processors
       end
 
       def selected_layers(image)
-        layer_index = directives.fetch(:layer, false)
-        return image unless layer_index
-        image.layers[layer_index]
+        if image.type =~ /pdf/i
+          image.layers[directives.fetch(:layer, 0)]
+        elsif directives.fetch(:layer, false)
+          image.layers[directives.fetch(:layer)]
+        else
+          image
+        end
       end
   end
 end


### PR DESCRIPTION
One last tweak, I hope.

For the PDF thumbnail generation to be effective, users would need to add the `layer: 0` directive to their application code, so instead let's just default it to the first layer if we're coming from a pdf. This also fixes another problem with thumbnails of office documents. Because we're passing a pdf to the image converter internally when we convert office documents to images, we won't need to specify a layer directive there either.

Alternatively, we could pass a layer directive to the image processor from the document processor, and leave the existing image processor code unchanged, but that would still leave existing implementations with the task of overriding their `create_derivatives` methods to pass that layer directive in for all their other pdfs.

This PR should make default hydra installations behave correctly, with multi-page PDFs and office documents converted to images using their first pages only, while allowing for specific layer directives should the user choose them.