### PR TITLE
Expand build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 cache: bundler
 sudo: false
-before_install: gem install rainbow
+before_install:
+  - gem update --system
+  - gem install bundler
 rvm:
   - 2.2.5
   - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ cache: bundler
 sudo: false
 rvm:
   - 2.2.5
+  - 2.3.1
+  - 2.4.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
+before_install: gem install rainbow
 rvm:
   - 2.2.5
   - 2.3.1


### PR DESCRIPTION
This test suite runs in less than a minute, we can afford to flesh out the build matrix for better coverage and earlier detection of deprecations.