### PR TITLE
Fixed a spec.  On OSX, the ENV['TEMPDIR'] might be under /var/folders instead of /tmp

### DIFF
--- a/spec/units/config_spec.rb
+++ b/spec/units/config_spec.rb
@@ -5,8 +5,11 @@ describe "the configuration" do
 
   before do
     # It's not always /tmp; it depends on OS and ENV vars
+    subject.temp_file_base = nil
     allow(Dir).to receive(:tmpdir).and_return('/tmp')
   end
+
+  after { subject.temp_file_base = nil }
 
   it "has some configuration defaults" do
     expect(subject.ffmpeg_path).to eq('ffmpeg')


### PR DESCRIPTION
I thought I had fixed this in my last commit, but that only fixed the problem when I ran the spec individually, and the spec was still broken when I ran the whole suite.  This change fixes the spec when the whole suite is run.