### PR TITLE
Add a service to check ffmepg installed codecs

### DIFF
--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -26,6 +26,7 @@ module Hydra
     autoload :Logger
     autoload :TempfileService
     autoload :IoDecorator
+    autoload :AudioEncoder
 
     autoload_under 'services' do
       autoload :RetrieveSourceFileService

--- a/lib/hydra/derivatives/audio_encoder.rb
+++ b/lib/hydra/derivatives/audio_encoder.rb
@@ -1,0 +1,27 @@
+require 'open3'
+
+module Hydra::Derivatives
+  class AudioEncoder
+    def initialize
+      @ffmpeg_output = Open3.capture3('ffmpeg -codecs').to_s
+    rescue
+      Logger.warn('Unable to find ffmpeg')
+      @ffmpeg_output = ""
+    end
+
+    def audio_encoder
+      audio_encoder = if fdk_aac?
+                        'libfdk_aac'
+                      else
+                        'aac'
+                      end
+      audio_encoder
+    end
+
+    private
+
+      def fdk_aac?
+        @ffmpeg_output.include?('--enable-libfdk-aac') || @ffmpeg_output.include?('--with-fdk-aac')
+      end
+  end
+end

--- a/lib/hydra/derivatives/processors/video/config.rb
+++ b/lib/hydra/derivatives/processors/video/config.rb
@@ -19,7 +19,8 @@ module Hydra::Derivatives::Processors::Video
     end
 
     def mpeg4
-      @mpeg4 ||= CodecConfig.new('-vcodec libx264 -acodec libfdk_aac')
+      audio_encoder = Hydra::Derivatives::AudioEncoder.new
+      @mpeg4 ||= CodecConfig.new("-vcodec libx264 -acodec #{audio_encoder.audio_encoder}")
     end
 
     def webm

--- a/lib/hydra/derivatives/services/capability_service.rb
+++ b/lib/hydra/derivatives/services/capability_service.rb
@@ -1,0 +1,17 @@
+require 'open3'
+
+module Hydra::Derivatives
+  class CapabilityService
+    attr_accessor :ffmpeg_output
+    def capture_output
+      @ffmpeg_output = Open3.capture3('ffmpeg -codecs').to_s
+    rescue
+      Logger.warn('Unable to find ffmpeg')
+      @ffmpeg_output = ""
+    end
+
+    def fdk_aac?
+      @ffmpeg_output.include?('--enable-libfdk-aac') || @ffmpeg_output.include?('--with-fdk-aac')
+    end
+  end
+end

--- a/spec/units/audio_encoder_spec.rb
+++ b/spec/units/audio_encoder_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::AudioEncoder do
+  before do
+    @audio_encoder = described_class.new
+  end
+
+  describe 'fdk_aac?' do
+    it 'outpus libfdk_aac if your ffmpeg was compiled with the library' do
+      enable_libfdk_flags = '--enable-gpl --enable-version3 --enable-nonfree --enable-hardcoded-tables --enable-avresample --with-fdk-aac'
+      @audio_encoder.instance_variable_set(:@ffmpeg_output, enable_libfdk_flags)
+      audio_encoder = @audio_encoder.audio_encoder
+      expect(audio_encoder).to eq('libfdk_aac')
+    end
+
+    it 'outputs aac if your ffmpeg was compiled with the library' do
+      enable_libfdk_flags = '--enable-gpl --enable-version3 --enable-nonfree --enable-hardcoded-tables --enable-avresample'
+      @audio_encoder.instance_variable_set(:@ffmpeg_output, enable_libfdk_flags)
+      audio_encoder = @audio_encoder.audio_encoder
+      expect(audio_encoder).to eq('aac')
+    end
+  end
+end


### PR DESCRIPTION
This adds a service to check ffmpeg installed codecs for FDK. If you don't have that it will 
use the default AAC encoder in ffmpeg.