### PR TITLE
Fix failing test for creation of JPEG2000 derivatives.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/
 .ruby-gemset
 fcrepo4-data/
 fcrepo4-test-data/
+coverage/

--- a/lib/hydra/derivatives/processors/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/processors/jpeg2k_image.rb
@@ -73,20 +73,18 @@ module Hydra::Derivatives::Processors
         rates.map(&:to_s).join(',')
       end
 
-      protected
+      def encode(path, recipe, output_file)
+        kdu_compress = Hydra::Derivatives.kdu_compress_path
+        execute "#{kdu_compress} -quiet -i #{path} -o #{output_file} #{recipe}"
+      end
 
-        def encode(path, recipe, output_file)
-          kdu_compress = Hydra::Derivatives.kdu_compress_path
-          execute "#{kdu_compress} -quiet -i #{path} -o #{output_file} #{recipe}"
-        end
+      def tmp_file(ext)
+        Dir::Tmpname.create(['sufia', ext], Hydra::Derivatives.temp_file_base) {}
+      end
 
-        def tmp_file(ext)
-          Dir::Tmpname.create(['sufia', ext], Hydra::Derivatives.temp_file_base) {}
-        end
-
-        def long_dim(image)
-          [image[:width], image[:height]].max
-        end
+      def long_dim(image)
+        [image[:width], image[:height]].max
+      end
     end
 
     def process

--- a/spec/processors/jpeg2k_spec.rb
+++ b/spec/processors/jpeg2k_spec.rb
@@ -3,6 +3,8 @@ require 'yaml'
 
 describe Hydra::Derivatives::Processors::Jpeg2kImage do
   let(:object) { ActiveFedora::Base.new }
+  let(:filename) { File.expand_path('../../fixtures/test.tif', __FILE__) }
+  let(:image) { MiniMagick::Image.open(filename) }
 
   describe "#calculate_recipe" do
     it "calculates the number of levels from a size" do
@@ -52,6 +54,27 @@ describe Hydra::Derivatives::Processors::Jpeg2kImage do
       args = {}
       r = described_class.kdu_compress_recipe(args, 'grey', 7200)
       expect(r).to eq(described_class.calculate_recipe(args, 'grey', 7200))
+    end
+  end
+
+  describe "#encode" do
+    it "executes the external utility" do
+      expect(described_class).to receive(:execute) { 0 }
+      described_class.encode('infile', 'recipe', 'outfile')
+      # expect(Hydra::Derivatives::Processors::ShellBasedProcessor).to have_received(:execute)
+    end
+  end
+
+  describe "#tmp_file" do
+    it "returns a temp file with the correct extension" do
+      f = described_class.tmp_file('test')
+      expect(f).to match(/sufia.*test$/)
+    end
+  end
+
+  describe "long_dim" do
+    it "returns the image's largest dimension" do
+      expect(described_class.long_dim(image)).to eq(386)
     end
   end
 end

--- a/spec/processors/jpeg2k_spec.rb
+++ b/spec/processors/jpeg2k_spec.rb
@@ -61,14 +61,13 @@ describe Hydra::Derivatives::Processors::Jpeg2kImage do
     it "executes the external utility" do
       expect(described_class).to receive(:execute) { 0 }
       described_class.encode('infile', 'recipe', 'outfile')
-      # expect(Hydra::Derivatives::Processors::ShellBasedProcessor).to have_received(:execute)
     end
   end
 
   describe "#tmp_file" do
     it "returns a temp file with the correct extension" do
-      f = described_class.tmp_file('test')
-      expect(f).to match(/sufia.*test$/)
+      f = described_class.tmp_file('.test')
+      expect(f).to end_with('.test')
     end
   end
 

--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -58,10 +58,10 @@ describe "Transcoding" do
         when 'image/tiff'
           Jpeg2kImageDerivatives.create(self, source: :original_file,
                                               outputs: [
-                                                { label: :resized,       recipe: :default, processor: 'jpeg2k_image', resize: "600x600>", url: "#{uri}/resized" },
-                                                { label: :config_lookup, recipe: :default, processor: 'jpeg2k_image',                     url: "#{uri}/config_lookup" },
-                                                { label: :string_recipe, recipe: '-quiet', processor: 'jpeg2k_image',                     url: "#{uri}/string_recipe" },
-                                                { label: :diy,                             processor: 'jpeg2k_image',                     url: "#{uri}/original_file_diy" }])
+                                                { label: :resized,       format: 'jp2', recipe: :default, processor: 'jpeg2k_image', resize: "600x600>", url: "#{uri}/resized" },
+                                                { label: :config_lookup, format: 'jp2', recipe: :default, processor: 'jpeg2k_image', url: "#{uri}/config_lookup" },
+                                                { label: :string_recipe, format: 'jp2', recipe: '-jp2_space sRGB', processor: 'jpeg2k_image', url: "#{uri}/string_recipe" },
+                                                { label: :diy,           format: 'jp2', processor: 'jpeg2k_image', url: "#{uri}/original_file_diy" }])
         when 'image/x-adobe-dng'
           ImageDerivatives.create(self, source: :original_file,
                                         outputs: [
@@ -318,6 +318,7 @@ describe "Transcoding" do
     let(:file) do
       GenericFile.new(mime_type_from_fits: 'image/tiff').tap do |t|
         t.original_file.content = attachment
+        t.original_file.mime_type = 'image/tiff'
         t.save
       end
     end


### PR DESCRIPTION
Fixes #118 by un-protecting some class methods that were originally not actually protected, but then made protected by rubocop. Specs for these methods coming shortly...
.jp2 derivatives tests were still broken due to .txt being used as a default mime-type and extension, so that is explicitly set now.