### PR TITLE
Fix 'attach RAW image' specs

### DIFF
--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -65,8 +65,8 @@ describe "Transcoding" do
         when 'image/x-adobe-dng'
           ImageDerivatives.create(self, source: :original_file,
                                         outputs: [
-                                          { label: :access, size: "300x300>", format: 'jpg', processor: :raw_image },
-                                          { label: :thumb,  size: "100x100>", format: 'jpg', processor: :raw_image }])
+                                          { label: :access, size: "300x300>", format: 'jpg', processor: :raw_image, url: "#{uri}/original_file_access" },
+                                          { label: :thumb,  size: "100x100>", format: 'jpg', processor: :raw_image, url: "#{uri}/original_file_thumb" }])
         end
       end
     end
@@ -113,14 +113,15 @@ describe "Transcoding" do
     end
 
     it "transcodes" do
-      expect(file.attached_files.key?('access')).to be_falsey
-      expect(file.attached_files.key?('thumb')).to be_falsey
+      expect(file.attached_files.key?('original_file_access')).to be_falsey
+      expect(file.attached_files.key?('original_file_thumb')).to be_falsey
 
       file.create_derivatives(filename)
-      expect(file.attached_files['access']).to have_content
-      expect(file.attached_files['access'].mime_type).to eq('image/jpeg')
-      expect(file.attached_files['thumb']).to have_content
-      expect(file.attached_files['thumb'].mime_type).to eq('image/jpeg')
+      file.reload
+      expect(file.attached_files['original_file_access']).to have_content
+      expect(file.attached_files['original_file_access'].mime_type).to eq('image/jpeg')
+      expect(file.attached_files['original_file_thumb']).to have_content
+      expect(file.attached_files['original_file_thumb'].mime_type).to eq('image/jpeg')
     end
   end
 


### PR DESCRIPTION
Fixes failures when running https://github.com/projecthydra/hydra-derivatives/blob/master/spec/units/transcoding_spec.rb#L104 for attaching RAW image derivatives.

Closes #145 

I had to run `brew install ufraw` for RAW file processing support in ImageMagick to fix the following error:

```
Failure/Error: MiniMagick::Image.open(source_path)
     
     MiniMagick::Invalid:
       `identify /var/folders/3q/6phb_54d571483_gf73qdk2cfwtt1d/T/mini_magick20170403-56719-ypwzbc.dng` failed with error:
       identify: delegate failed `'ufraw-batch' --silent --create-id=also --out-type=png --out-depth=16 '--output=%u.png' '%i'' @ error/delegate.c/InvokeDelegate/1845.
```

After installing ufraw, the changes in this PR fix these errors:

```
Failure/Error: uri = URI(directives.fetch(:url))
     
     KeyError:
       key not found: :url
```

```
Failure/Error: expect(file.attached_files['access']).to have_content
       expected  to respond to `has_content?`
```