### PR TITLE
Handle the case where active_encode returns a 'cancelled' status

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,10 @@ Style/PredicateName:
 Style/RaiseArgs:
   Enabled: false
 
+Style/HashSyntax:
+  Exclude:
+    - spec/processors/active_encode_spec.rb
+
 RSpec/ExampleWording:
   CustomTransform:
     be: is

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -4,19 +4,22 @@ module Hydra::Derivatives::Processors
   class ActiveEncode < Processor
     def process
       encode = ::ActiveEncode::Base.create(source_path, directives)
-
-      # TODO: wait until the encode job succeeds then call output_file_service with the output url
-      # while(encode.reload.running?) do
-      #   p "Wait: #{Time.now}"
-      #   sleep 10
-      # end
+      # while(encode.reload.running?) { sleep 10 }
 
       raise_exception_if_encoding_failed(encode)
+      raise_exception_if_encoding_cancelled(encode)
+
+      # TODO: call output_file_service with the output url
     end
 
     def raise_exception_if_encoding_failed(encode)
       return unless encode.failed?
       raise StandardError.new("Encoding failed: #{encode.errors.join(' ; ')}")
+    end
+
+    def raise_exception_if_encoding_cancelled(encode)
+      return unless encode.cancelled?
+      raise StandardError.new("Encoding cancelled: #{source_path}")
     end
   end
 end

--- a/lib/hydra/derivatives/services/uri_source_file_service.rb
+++ b/lib/hydra/derivatives/services/uri_source_file_service.rb
@@ -5,7 +5,7 @@ module Hydra::Derivatives
     # @param [Hash] options
     # @option options [Symbol] :source a method that can be called on the object to retrieve the source file
     # @yield [Tempfile] a temporary source file that has a lifetime of the block
-    def self.call(object, options, &block)
+    def self.call(object, options, &_block)
       source_name = options.fetch(:source)
       yield(object.send(source_name).uri.to_s)
     end


### PR DESCRIPTION
Part of story avalonmediasystem/avalon#1785