### PR TITLE
Add filename to error message

### DIFF
--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -4,6 +4,8 @@ module Hydra::Derivatives::Processors
   class ActiveEncode < Processor
     def process
       encode = ::ActiveEncode::Base.create(source_path, directives)
+
+      # Wait until the encoding job is finished
       # while(encode.reload.running?) { sleep 10 }
 
       raise_exception_if_encoding_failed(encode)
@@ -14,12 +16,12 @@ module Hydra::Derivatives::Processors
 
     def raise_exception_if_encoding_failed(encode)
       return unless encode.failed?
-      raise StandardError.new("Encoding failed: #{encode.errors.join(' ; ')}")
+      raise StandardError.new("Encoding failed for #{source_path}: #{encode.errors.join(' ; ')}")
     end
 
     def raise_exception_if_encoding_cancelled(encode)
       return unless encode.cancelled?
-      raise StandardError.new("Encoding cancelled: #{source_path}")
+      raise StandardError.new("Encoding cancelled for #{source_path}")
     end
   end
 end

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -33,7 +33,7 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error('Encoding failed: error 1 ; error 2')
+        expect { subject }.to raise_error("Encoding failed for #{file_path}: error 1 ; error 2")
       end
     end
 
@@ -46,7 +46,7 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error("Encoding cancelled: #{file_path}")
+        expect { subject }.to raise_error("Encoding cancelled for #{file_path}")
       end
     end
   end

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -15,10 +15,12 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
     # encode finished and returned a certain status.
     let(:failed_status) { false }
     let(:cancelled_status) { false }
+    let(:completed_status) { false }
     let(:errors) { [] }
     let(:encode_double) do
       double('encode double',
              reload: self, state: state, errors: errors,
+             :completed? => completed_status,
              :failed? => failed_status,
              :cancelled? => cancelled_status)
     end
@@ -33,7 +35,7 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error("Encoding failed for #{file_path}: error 1 ; error 2")
+        expect { subject }.to raise_error(Hydra::Derivatives::Processors::ActiveEncodeError, "ActiveEncode status was \"failed\" for #{file_path}: error 1 ; error 2")
       end
     end
 
@@ -46,7 +48,7 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error("Encoding cancelled for #{file_path}")
+        expect { subject }.to raise_error(Hydra::Derivatives::Processors::ActiveEncodeError, "ActiveEncode status was \"cancelled\" for #{file_path}")
       end
     end
   end


### PR DESCRIPTION
Because I'm submitting 2 PRs in a row against the same branch, the diff for this PR will also include the changes for PR #150 until PR #150 gets merged.

The true diff for this PR is quite small.  You can see it here:
https://github.com/projecthydra/hydra-derivatives/compare/cancelled_status...add_filename_to_error_message

Please merge PR #150 before this one.  Thanks!