### PR TITLE
Preserve the 2nd error message in the case where an error is raised during the cleanup after a timeout error.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,10 +48,6 @@ Style/HashSyntax:
   Exclude:
     - spec/processors/active_encode_spec.rb
 
-Lint/HandleExceptions:
-  Exclude:
-    - lib/hydra/derivatives/processors/active_encode.rb
-
 RSpec/ExampleWording:
   CustomTransform:
     be: is


### PR DESCRIPTION
This PR is meant to address this comment by @mjgiarlo in a previous PR:
https://github.com/projecthydra/hydra-derivatives/pull/154#issuecomment-295462717

The situation that this code is trying to handle:
If a Timeout error is raised, we try to clean up our resources by cancelling the encoding.  If an exception is raised during the cleanup, we don't want the original Timeout error to be lost.

The current solution:
The way I have done it here is to rescue any error and re-raise the Timeout error with the new error message appended to it.

@mjgiarlo Do you think it's sufficient to tack the 2nd error message onto the first Timeout error, no matter what type of error was raised?  Or do you think it's better to pursue the goal of rescuing specific errors?  Can you think of a nicer way to raise a 2nd error without losing the first one?

Another possible solution would be to rescue specific errors, but there are some problems with that solution:

* In addition to the known types of errors we need to rescue, there may be unknown types.  Because the `encode.cancel!' method also runs callbacks, the implementer might add code in a callback that raises unknown exceptions.

* ActiveEncode allows the implementer to choose from at least 4 different encoding services.  If we try to rescue errors from each of those different services, I think we would end up having to include all of those gems as dependencies in `hydra-derivatives` just to be able to rescue their errors.  For example, if I try to rescue `Aws::Errors::ServiceError` without having the `aws-sdk` gem installed, I'll get `NameError: uninitialized constant Aws`.

* Coupling between `active_encode` and `hydra-derivatives`:  Each time we add a new encoder adapter to `active_encode`, we may need to add new error(s) to our `rescue` block in `hydra-derivatives`.

If we do want to rescue specific errors, the code would look something like this:

```ruby
errors_to_rescue = [
  Zencoder::HTTPError,
  Aws::Errors::ServiceError,
  RubyhornException,
  # Does Shingoncoder have a base error class?
  # possibly more?
]

# After a timeout error, try to cancel the encoding.
def cleanup_after_timeout(encode)
  encode.cancel!
rescue *errors_to_rescue => e
  cancel_error = e
ensure
  msg = "The original timeout error message"
  msg = "#{msg} An error occurred while trying to cancel encoding: #{cancel_error}" if cancel_error
  raise Hydra::Derivatives::TimeoutError, msg
end
```