### PR TITLE
Persist active encode results in ActiveFedora::File objects with external content

### DIFF
--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -36,9 +36,9 @@ module Hydra
       autoload :RemoteSourceFile
       autoload :PersistOutputFileService
       autoload :PersistBasicContainedOutputFileService
+      autoload :PersistExternalFileOutputFileService
       autoload :TempfileService
       autoload :MimeTypeService
-      autoload :NullOutputFileService
     end
 
     # Raised if the timout elapses

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -18,7 +18,9 @@ module Hydra::Derivatives::Processors
     def process
       encode = ::ActiveEncode::Base.create(source_path, directives)
       timeout ? wait_for_encode_with_timeout(encode) : wait_for_encode(encode)
-      # TODO: call output_file_service with the output url
+      encode.output.each do |output|
+        output_file_service.call(output, directives)
+      end
     end
 
     def wait_for_encode_with_timeout(encode)

--- a/lib/hydra/derivatives/runners/active_encode_derivatives.rb
+++ b/lib/hydra/derivatives/runners/active_encode_derivatives.rb
@@ -20,7 +20,7 @@ module Hydra::Derivatives
 
     # Use the output service configured for this class or default to the null output service
     def self.output_file_service
-      @output_file_service || NullOutputFileService
+      @output_file_service || PersistExternalFileOutputFileService
     end
 
     def self.processor_class

--- a/lib/hydra/derivatives/services/null_output_file_service.rb
+++ b/lib/hydra/derivatives/services/null_output_file_service.rb
@@ -1,7 +1,0 @@
-module Hydra::Derivatives
-  class NullOutputFileService
-    def self.call(_stream, _directives)
-      # no-op
-    end
-  end
-end

--- a/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
@@ -1,0 +1,18 @@
+module Hydra::Derivatives
+  class PersistExternalFileOutputFileService < PersistOutputFileService
+    # Persists a new file at specified location that points to external content
+    # @param [Hash] output information about the external derivative file
+    # @option output [String] url the location of the external content
+    # @param [Hash] directives directions which can be used to determine where to persist to.
+    # @option directives [String] url This can determine the path of the object.
+    def self.call(output, directives)
+      external_file = ActiveFedora::File.new(directives[:url])
+      # TODO: Replace the following two lines with the shorter call to #external_url once active_fedora/pull/1234 is merged
+      external_file.content = ''
+      external_file.mime_type = "message/external-body; access-type=URL; URL=\"#{output[:url]}\""
+      # external_file.external_url = output[:url]
+      external_file.original_name = URI.parse(output[:url]).path.split('/').last
+      external_file.save
+    end
+  end
+end

--- a/spec/runners/active_encode_derivatives_spec.rb
+++ b/spec/runners/active_encode_derivatives_spec.rb
@@ -13,7 +13,7 @@ describe Hydra::Derivatives::ActiveEncodeDerivatives do
     let(:processor) { double('processor') }
 
     it 'calls the processor with the right arguments' do
-      expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::NullOutputFileService).and_return(processor)
+      expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService).and_return(processor)
       expect(processor).to receive(:process)
       described_class.create(video_record, options)
     end

--- a/spec/services/persist_external_file_output_file_service_spec.rb
+++ b/spec/services/persist_external_file_output_file_service_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::PersistExternalFileOutputFileService do
+  before do
+    class ExternalDerivativeContainerObject < ActiveFedora::Base
+      has_subresource "external_derivative"
+    end
+  end
+  after do
+    Object.send(:remove_const, :ExternalDerivativeContainerObject)
+  end
+
+  let(:object)            { ExternalDerivativeContainerObject.create }
+  let(:directives)        { { url: "#{object.uri}/external_derivative" } }
+  let(:external_url)      { 'http://www.example.com/external/content' }
+  let(:output)            { { url: external_url } }
+  let(:destination_name)  { 'external_derivative' }
+
+  describe '.call' do
+    it "persists the external file to the specified destination on the given object" do
+      described_class.call(output, directives)
+      expect(object.send(destination_name.to_sym).mime_type).to eq "message/external-body;access-type=URL;url=\"http://www.example.com/external/content\""
+      expect(object.send(destination_name.to_sym).content).to eq ''
+    end
+  end
+end


### PR DESCRIPTION
The PersistExternalFileOutputFileService has a slightly different interface than the other output file services.  It takes a hash of information about the output file created through ActiveEncode instead of an open File object or String.  I left a TODO to update the code for when projecthydra/active_fedora#1234 gets merged.